### PR TITLE
CVR として NaN% が出ないように修正

### DIFF
--- a/scripts/src/index.ts
+++ b/scripts/src/index.ts
@@ -30,18 +30,33 @@ const createConversionUUElement = (value: number) => {
   return element;
 };
 
+const getNumberOnTheScreenByClassName = (className: string) =>
+  new Promise<number>((resolve) => {
+    const elem = document.getElementsByClassName(className)[0];
+
+    const textContent = elem?.textContent.trim() ?? '';
+    if (textContent !== '') {
+      resolve(+textContent);
+      return;
+    }
+
+    const observer = new MutationObserver(([{ target }]) => {
+      observer.disconnect();
+      resolve(+target.textContent);
+    });
+    observer.observe(elem, { childList: true });
+  });
+
 // CVR書き込み
-onReady(() => {
+onReady(async () => {
   const eventStatsElements = document.getElementsByClassName(
     'EventStatsHero stats_hero_area flex-row'
   );
-  const pageview =
-    +document.getElementsByClassName('PageviewsHero num')[0].innerHTML;
-  const visitor =
-    +document.getElementsByClassName('VisitorsHero num')[0].innerHTML;
-  const participation = +document.getElementsByClassName(
+  const pageview = await getNumberOnTheScreenByClassName('PageviewsHero num');
+  const visitor = await getNumberOnTheScreenByClassName('VisitorsHero num');
+  const participation = await getNumberOnTheScreenByClassName(
     'ParticipationsHero num'
-  )[0].innerHTML;
+  );
 
   const conversionRatePV = Math.floor((participation / pageview) * 1000) / 10;
   const conversionRatePVElement = createConversionPVElement(conversionRatePV);

--- a/scripts/src/index.ts
+++ b/scripts/src/index.ts
@@ -1,24 +1,9 @@
-// CVR書き込み
-window.onload = function () {
-  const eventStatsElements = document.getElementsByClassName(
-    'EventStatsHero stats_hero_area flex-row'
-  );
-  const pageview =
-    +document.getElementsByClassName('PageviewsHero num')[0].innerHTML;
-  const visitor =
-    +document.getElementsByClassName('VisitorsHero num')[0].innerHTML;
-  const participation = +document.getElementsByClassName(
-    'ParticipationsHero num'
-  )[0].innerHTML;
-
-  const conversionRatePV = Math.floor((participation / pageview) * 1000) / 10;
-  const conversionRatePVElement = createConversionPVElement(conversionRatePV);
-
-  const conversionRateUU = Math.floor((participation / visitor) * 1000) / 10;
-  const conversionRateUUElement = createConversionUUElement(conversionRateUU);
-
-  eventStatsElements[0].appendChild(conversionRatePVElement);
-  eventStatsElements[0].appendChild(conversionRateUUElement);
+const onReady = (cb: () => void) => {
+  if (document.readyState !== 'loading') {
+    cb();
+  } else {
+    document.addEventListener('DOMContentLoaded', cb);
+  }
 };
 
 const createConversionPVElement = (value: number) => {
@@ -44,3 +29,26 @@ const createConversionUUElement = (value: number) => {
   element.style.color = '#0090c9';
   return element;
 };
+
+// CVR書き込み
+onReady(() => {
+  const eventStatsElements = document.getElementsByClassName(
+    'EventStatsHero stats_hero_area flex-row'
+  );
+  const pageview =
+    +document.getElementsByClassName('PageviewsHero num')[0].innerHTML;
+  const visitor =
+    +document.getElementsByClassName('VisitorsHero num')[0].innerHTML;
+  const participation = +document.getElementsByClassName(
+    'ParticipationsHero num'
+  )[0].innerHTML;
+
+  const conversionRatePV = Math.floor((participation / pageview) * 1000) / 10;
+  const conversionRatePVElement = createConversionPVElement(conversionRatePV);
+
+  const conversionRateUU = Math.floor((participation / visitor) * 1000) / 10;
+  const conversionRateUUElement = createConversionUUElement(conversionRateUU);
+
+  eventStatsElements[0].appendChild(conversionRatePVElement);
+  eventStatsElements[0].appendChild(conversionRateUUElement);
+});


### PR DESCRIPTION
# PR 概要
- `window.onload` をやめて `document.addEventListener` を使うようにしました
  - `document.readyState` 次第では `DOMContentLoaded` イベントが発火しないことがあるので、その場合はコールバック関数を直接呼び出しています
- 稀に CVR(PV), CVR(UU) として NaN% が表示されるのを修正しました
  - 数回リロードすると NaN% が出ることがありました
    - <img width="1061" alt="スクリーンショット 2023-08-27 16 16 29" src="https://github.com/tokku5552/connpass-advanced-stats/assets/13311608/60029b26-c0a2-4734-89d5-51605e6b98b3">
  - MutationObserver を利用して画面上に数値が反映されるのを待つようにしました

## 関連 ISSUE

## その他

- なし
