### PR TITLE
refactor: build conversion DOM without innerHTML

### DIFF
--- a/scripts/src/index.ts
+++ b/scripts/src/index.ts
@@ -8,24 +8,42 @@ const onReady = (cb: () => void) => {
 
 const createConversionPVElement = (value: number) => {
   const element = document.createElement('div');
-  element.innerHTML = `
-    <div class="list conversions">
-      <p>CVR(PV)</p>
-      <p class="ConversionHero num">${value}%</p>
-    </div>
-    `;
+
+  const list = document.createElement('div');
+  list.className = 'list conversions';
+
+  const label = document.createElement('p');
+  label.textContent = 'CVR(PV)';
+
+  const valueElem = document.createElement('p');
+  valueElem.className = 'ConversionHero num';
+  valueElem.textContent = `${value}%`;
+
+  list.appendChild(label);
+  list.appendChild(valueElem);
+  element.appendChild(list);
+
   element.style.color = '#ff9900';
   return element;
 };
 
 const createConversionUUElement = (value: number) => {
   const element = document.createElement('div');
-  element.innerHTML = `
-    <div class="list conversions">
-      <p>CVR(UU)</p>
-      <p class="ConversionHero num">${value}%</p>
-    </div>
-    `;
+
+  const list = document.createElement('div');
+  list.className = 'list conversions';
+
+  const label = document.createElement('p');
+  label.textContent = 'CVR(UU)';
+
+  const valueElem = document.createElement('p');
+  valueElem.className = 'ConversionHero num';
+  valueElem.textContent = `${value}%`;
+
+  list.appendChild(label);
+  list.appendChild(valueElem);
+  element.appendChild(list);
+
   element.style.color = '#0090c9';
   return element;
 };


### PR DESCRIPTION
## Summary
- build conversion rate elements using DOM APIs instead of `innerHTML`

## Testing
- `npx eslint scripts/src/index.ts`
- `npx tsc -p scripts`
- `npx jest scripts --passWithNoTests`
- `npx prettier scripts/src/index.ts -c`


------
https://chatgpt.com/codex/tasks/task_e_68abcf559120832dac2b28d24ad18b66