### PR TITLE
feat: set minimal CSP for extension pages

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -3,6 +3,9 @@
   "name": "connpass advanced stats",
   "description": "connpass advanced stats",
   "version": "1.0",
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  },
   "content_scripts": [
     {
       "matches": [


### PR DESCRIPTION
## Summary
- add `content_security_policy` to extension manifest to restrict scripts and objects to self

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68abcf5f1804832da2bfef5f0f27754d