### PR TITLE
ci: add npm audit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,8 @@ on:
       - scripts/**
 
 jobs:
-  ci:
+  prepare:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        task: [lint, test, build]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -33,6 +30,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           yarn install
+
   audit:
     runs-on: ubuntu-latest
     needs: prepare
@@ -48,6 +46,10 @@ jobs:
         with:
           path: "**/node_modules"
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
+      - name: yarn install
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          yarn install
       - name: npm audit
         run: |
           yarn npm audit --all --json > audit.json || true
@@ -56,6 +58,7 @@ jobs:
             jq '.metadata.vulnerabilities' audit.json
             exit 1
           fi
+
   lint:
     runs-on: ubuntu-latest
     needs: prepare
@@ -71,8 +74,13 @@ jobs:
         with:
           path: "**/node_modules"
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
+      - name: yarn install
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          yarn install
       - name: yarn lint
         run: yarn lint
+
   test:
     runs-on: ubuntu-latest
     needs: prepare
@@ -88,9 +96,14 @@ jobs:
         with:
           path: "**/node_modules"
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
+      - name: yarn install
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          yarn install
       - name: test
         run: |
           yarn test
+
   build:
     runs-on: ubuntu-latest
     needs: prepare
@@ -106,17 +119,18 @@ jobs:
         with:
           path: "**/node_modules"
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
+      - name: yarn install
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          yarn install
       - name: build
         run: |
           yarn build
       - name: Update manifest.json
-        if: matrix.task == 'build'
         run: npx dot-json@1 extensions/manifest.json version dummy
       - name: Archive
-        if: matrix.task == 'build'
         run: zip -r extension.zip ./extensions
       - name: Check Archive
-        if: matrix.task == 'build'
         run: |
           rm -rf ./extensions
           unzip extension.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,29 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           yarn install
+  audit:
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Cache node modules
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: "**/node_modules"
+          key: cache-node-modules-${{ hashFiles('yarn.lock') }}
+      - name: npm audit
+        run: |
+          yarn npm audit --all --json > audit.json || true
+          if [ $(jq '.metadata.vulnerabilities | values | add' audit.json) -gt 0 ]; then
+            echo 'Vulnerabilities found:'
+            jq '.metadata.vulnerabilities' audit.json
+            exit 1
+          fi
   lint:
     runs-on: ubuntu-latest
     needs: prepare

--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ yarn build
 
 FYI: [React でサクッと chrome の拡張機能をつくる](<https://zenn.dev/tokku5552/articles/how-to-make-chrome-extension#%E4%BD%BF%E3%81%84%E6%96%B9(%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E3%83%93%E3%83%AB%E3%83%89)>)
 
+## セキュリティチェック
+
+依存パッケージの脆弱性を検知するため、CI では `npm audit` を実行しています。脆弱性が検出されるとジョブが失敗し、Pull Request のマージがブロックされます。
+
+開発者はローカルでも以下のコマンドでチェックを実行できます。
+
+```bash
+yarn npm audit --all
+```
+
+脆弱性が報告された場合は `yarn npm audit --fix` やパッケージの更新を行い、必要に応じて Dependabot などで対応してください。
+
 ## Contributing
 
 BUG の報告や機能追加の要望等は[ISSUE Template](https://github.com/tokku5552/connpass-advanced-stats/issues/new/choose)から該当するものを選んで、ISSUE を作成してください。


### PR DESCRIPTION
## Summary
- add npm audit job to CI
- document how to check/fix dependency vulnerabilities

## Testing
- `yarn lint`
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68abcf5ccf48832db44a83d8a27393ab