### PR TITLE
refactor(ci): reuse setup steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,84 +12,29 @@ on:
       - scripts/**
 
 jobs:
-  prepare:
+  ci:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        task: [lint, test, build]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-
-      - name: Cache node modules
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: "**/node_modules"
-          key: cache-node-modules-${{ hashFiles('yarn.lock') }}
-      - name: yarn install
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          yarn install
-  lint:
-    runs-on: ubuntu-latest
-    needs: prepare
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
-      - name: Cache node modules
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: "**/node_modules"
-          key: cache-node-modules-${{ hashFiles('yarn.lock') }}
-      - name: yarn lint
-        run: yarn lint
-  test:
-    runs-on: ubuntu-latest
-    needs: prepare
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
-      - name: Cache node modules
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: "**/node_modules"
-          key: cache-node-modules-${{ hashFiles('yarn.lock') }}
-      - name: test
-        run: |
-          yarn test
-  build:
-    runs-on: ubuntu-latest
-    needs: prepare
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
-      - name: Cache node modules
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: "**/node_modules"
-          key: cache-node-modules-${{ hashFiles('yarn.lock') }}
-      - name: build
-        run: |
-          yarn build
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install
+      - name: Run ${{ matrix.task }}
+        run: yarn ${{ matrix.task }}
       - name: Update manifest.json
-        run: |
-          npx dot-json@1 extensions/manifest.json version dummy
+        if: matrix.task == 'build'
+        run: npx dot-json@1 extensions/manifest.json version dummy
       - name: Archive
-        run: |
-          zip -r extension.zip ./extensions
+        if: matrix.task == 'build'
+        run: zip -r extension.zip ./extensions
       - name: Check Archive
+        if: matrix.task == 'build'
         run: |
           rm -rf ./extensions
           unzip extension.zip


### PR DESCRIPTION
## Summary
- simplify CI by consolidating repeated setup steps
- leverage setup-node cache for yarn to eliminate explicit caching

## Testing
- `npm run lint` *(fails: connpass-advanced-stats@workspace: This package doesn't seem to be present in your lockfile)*
- `yarn install` *(fails: RequestError: Bad response: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68abcf5b808c832da8bb685c84b7c2d7