### PR TITLE
chore: remove unused placeholders

### DIFF
--- a/scripts/jest.config.js
+++ b/scripts/jest.config.js
@@ -4,5 +4,4 @@ module.exports = {
     '^.+\\.(ts|tsx)$': ['ts-jest', { tsConfig: 'tsconfig.json' }],
   },
   testMatch: ['**/*.spec.(ts|tsx)'],
-  globalSetup: './src/setupTests.ts',
 };

--- a/scripts/src/setupTests.ts
+++ b/scripts/src/setupTests.ts
@@ -1,6 +1,0 @@
-// export default (): void => {
-//   process.env.LINE_CHANNEL_ID = 'TEST_LINE_CHANNEL_ID';
-//   process.env.LINE_CHANNEL_SECRET = 'TEST_LINE_CHANNEL_SECRET';
-//   process.env.LINE_CHANNEL_ACCESS_TOKEN = 'TEST_LINE_CHANNEL_ACCESS_TOKEN';
-//   return;
-// };


### PR DESCRIPTION
## Summary
- remove unused placeholder data file
- remove unused test setup and its reference in scripts

## Testing
- `npm run build:prebuild`
- `npm run export --workspace=popup`
- `npm run build --workspace=scripts`
- `npm test --workspace=popup`
- `npm test --workspace=scripts -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68abcf5a7e64832db95768e39a0ffa9d