### PR TITLE
Enable strict TypeScript checking in scripts

### DIFF
--- a/scripts/src/index.ts
+++ b/scripts/src/index.ts
@@ -42,7 +42,7 @@ const getNumberOnTheScreenByClassName = (className: string) =>
 
     const observer = new MutationObserver(([{ target }]) => {
       observer.disconnect();
-      resolve(+target.textContent);
+      resolve(Number(target.textContent ?? 0));
     });
     observer.observe(elem, { childList: true });
   });

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "CommonJS",
     "sourceMap": true,
     "esModuleInterop": true,
+    "strict": true,
     "types": ["node", "jest"],
     "rootDir": "src",
     "outDir": "out"


### PR DESCRIPTION
## Summary
- enable TypeScript `strict` mode for scripts workspace
- handle possible null text content when reading from MutationObserver targets

## Testing
- `yarn workspace scripts tsc --noEmit` *(fails: This package doesn't seem to be present in your lockfile)*
- `node_modules/.bin/tsc -p scripts/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68abcf587388832da2950034824004a3