### PR TITLE
feat: add retry logic for DOM number lookup

### DIFF
--- a/scripts/src/index.spec.ts
+++ b/scripts/src/index.spec.ts
@@ -1,0 +1,27 @@
+import { getNumberOnTheScreenByClassName } from './index';
+
+describe('getNumberOnTheScreenByClassName', () => {
+  it('rejects when element not found', async () => {
+    await expect(
+      getNumberOnTheScreenByClassName('not-exist', 0)
+    ).rejects.toThrow('Element with class not-exist not found');
+  });
+
+  it('retries to find element and resolves when found', async () => {
+    jest.useFakeTimers();
+
+    setTimeout(() => {
+      const div = document.createElement('div');
+      div.className = 'appears-later';
+      div.textContent = '42';
+      document.body.appendChild(div);
+    }, 0);
+
+    const promise = getNumberOnTheScreenByClassName('appears-later', 1, 0);
+
+    jest.runAllTimers();
+    await expect(promise).resolves.toBe(42);
+
+    jest.useRealTimers();
+  });
+});

--- a/scripts/src/setupTests.ts
+++ b/scripts/src/setupTests.ts
@@ -1,6 +1,5 @@
-// export default (): void => {
-//   process.env.LINE_CHANNEL_ID = 'TEST_LINE_CHANNEL_ID';
-//   process.env.LINE_CHANNEL_SECRET = 'TEST_LINE_CHANNEL_SECRET';
-//   process.env.LINE_CHANNEL_ACCESS_TOKEN = 'TEST_LINE_CHANNEL_ACCESS_TOKEN';
-//   return;
-// };
+export default (): void => {
+  // process.env.LINE_CHANNEL_ID = 'TEST_LINE_CHANNEL_ID';
+  // process.env.LINE_CHANNEL_SECRET = 'TEST_LINE_CHANNEL_SECRET';
+  // process.env.LINE_CHANNEL_ACCESS_TOKEN = 'TEST_LINE_CHANNEL_ACCESS_TOKEN';
+};


### PR DESCRIPTION
## Summary
- handle missing DOM elements in `getNumberOnTheScreenByClassName` with retry and rejection
- skip DOM operations when running tests
- add tests for missing element cases

## Testing
- `npm run lint -w scripts` *(fails: package.json formatting)*
- `npm test -w scripts -- --env=jsdom`


------
https://chatgpt.com/codex/tasks/task_e_68abcf573af4832db4e5e5a5ac592742