### PR TITLE
Add supply chain attack mitigations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: yarn install
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          yarn install
+          yarn install --ignore-scripts
 
   audit:
     runs-on: ubuntu-latest
@@ -49,7 +49,7 @@ jobs:
       - name: yarn install
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          yarn install
+          yarn install --ignore-scripts
       - name: npm audit
         run: |
           yarn npm audit --all --json > audit.json || true
@@ -77,7 +77,7 @@ jobs:
       - name: yarn install
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          yarn install
+          yarn install --ignore-scripts
       - name: yarn lint
         run: yarn lint
 
@@ -99,7 +99,7 @@ jobs:
       - name: yarn install
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          yarn install
+          yarn install --ignore-scripts
       - name: test
         run: |
           yarn test
@@ -122,7 +122,7 @@ jobs:
       - name: yarn install
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          yarn install
+          yarn install --ignore-scripts
       - name: build
         run: |
           yarn build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
       - name: yarn install
         run: |
-          yarn install
+          yarn install --ignore-scripts
   release:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
@@ -40,7 +40,7 @@ jobs:
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
       - name: yarn install
         run: |
-          yarn install
+          yarn install --ignore-scripts
       - uses: fregante/daily-version-action@v2
         id: daily-version
       - name: build # NOTE: temporarily disable popup

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "minimumReleaseAge": "7 days",
   "extends": [
     "config:base"
   ],


### PR DESCRIPTION
## Summary
- CI ワークフロー（ci.yml, release.yml）の全 `yarn install` に `--ignore-scripts` フラグを追加し、postinstall フック経由のマルウェア実行を防止
- Renovate 設定に `minimumReleaseAge: 7 days` を追加し、npm 公開後7日未満のパッケージへの自動更新を抑制

## Background
2026/3/30 の axios 1.14.1 サプライチェーン攻撃への長期的な対策です。

## Test plan
- [ ] CI ワークフローの `yarn install` がすべて `--ignore-scripts` 付きであることを確認
- [ ] `renovate.json` が valid JSON であることを確認
- [ ] CI パイプラインが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)