### PR TITLE
Enable automerge for minor version updates in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,10 @@
   "major": {
     "enabled": false
   },
+  "minor": {
+    "automerge": true
+  },
+  "platformAutomerge": true,
   "packageRules": [
     {
       "groupName": "linters",


### PR DESCRIPTION
# PR 概要

- Renovate の設定を更新し、マイナーバージョンの更新に対して自動マージを有効化
- `minor.automerge` を `true` に設定
- `platformAutomerge` を `true` に設定して、プラットフォームレベルでの自動マージを有効化

## 関連 ISSUE

<!-- close #1-->

## その他

- なし

https://claude.ai/code/session_01UW48NYLtNZcpRrZ6HMY1Ea