### PR TITLE
fix: bot が作った PR の CI が承認待ちで止まるのを直す

### DIFF
--- a/.github/workflows/create_pr_main_to_develop.yml
+++ b/.github/workflows/create_pr_main_to_develop.yml
@@ -13,6 +13,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
+          # Use a PAT instead of GITHUB_TOKEN. Pull requests opened by
+          # github-actions[bot] have their workflow runs held in action_required
+          # until someone clicks "Approve and run", so CI never runs on its own.
+          token: ${{ secrets.AUTOMATION_PAT }}
 
       - name: Set current datetime as env variable
         env:
@@ -25,15 +29,13 @@ jobs:
       - name: Push Branch
         run: git push origin merge/gha_${{ env.CURRENT_DATETIME }}
 
-      - name: Install Hub
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y hub
-
       - name: Create Pull Request
         env:
-          REVIEWERS: "tokku5552"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTOMATION_PAT }}
           BRANCH_NAME: merge/gha_${{ env.CURRENT_DATETIME }}
         run: |
-          hub pull-request -m "[bot(create_pr_main_to_develop)]: created at ${{ env.CURRENT_DATETIME }}" -b develop -h $BRANCH_NAME  -r "$REVIEWERS"
+          gh pr create \
+            --base develop \
+            --head "$BRANCH_NAME" \
+            --title "[bot(create_pr_main_to_develop)]: created at ${{ env.CURRENT_DATETIME }}" \
+            --body "Sync pull request (main -> develop) after a release."

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -12,6 +12,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: develop
+          # Use a PAT instead of GITHUB_TOKEN. Pull requests opened by
+          # github-actions[bot] have their workflow runs held in action_required
+          # until someone clicks "Approve and run", so CI never runs on its own.
+          token: ${{ secrets.AUTOMATION_PAT }}
 
       - name: Set current datetime as env variable
         env:
@@ -24,15 +28,13 @@ jobs:
       - name: Push Branch
         run: git push origin release/gha_${{ env.CURRENT_DATETIME }}
 
-      - name: Install Hub
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y hub
-
       - name: Create Pull Request
         env:
-          REVIEWERS: "tokku5552"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTOMATION_PAT }}
           BRANCH_NAME: release/gha_${{ env.CURRENT_DATETIME }}
         run: |
-          hub pull-request -m "[bot(create_release_pr)]: created at ${{ env.CURRENT_DATETIME }}" -b main -h $BRANCH_NAME  -r "$REVIEWERS"
+          gh pr create \
+            --base main \
+            --head "$BRANCH_NAME" \
+            --title "[bot(create_release_pr)]: created at ${{ env.CURRENT_DATETIME }}" \
+            --body "Scheduled release pull request (develop -> main)."


### PR DESCRIPTION
# PR 概要

- 変更した点
  - `create_release_pr.yml` / `create_pr_main_to_develop.yml` で PR を作るトークンを `secrets.GITHUB_TOKEN` から `secrets.AUTOMATION_PAT` に変更（`actions/checkout` の `token:` と `gh` の `GH_TOKEN` の両方）
  - reviewer 指定 `-r "tokku5552"` を削除
  - deprecated な `hub pull-request` を `gh pr create` に置き換え、`Install Hub`（`apt-get update && apt-get install -y hub`）ステップを削除

## なぜ

`secrets.GITHUB_TOKEN` で PR を作ると作者が `github-actions[bot]` になる。GitHub の仕様変更により、bot が作った PR の workflow run は write 権限を持つユーザーが "Approve and run" を押すまで `action_required` で保留されるようになった。このため `release/gha_*` と `merge/gha_*` の PR では ci / labeler / auto assign が自動では走らない。

公式アナウンス: https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/

このリポジトリで観測された開始日は 2026-04-22（PR #784）。それ以前は GITHUB_TOKEN の再帰防止によって、これらの PR には CI が一度も走らないままマージされていた（#767 / #775 / #779 には ci の check が1つも無い）。段階的ロールアウトのため changelog の日付とはズレている。

PAT を使うと PR 作者が実ユーザーになるので、承認なしで workflow が走る。

## reviewer 指定を消した理由

PAT を使うと PR 作者が `tokku5552` になり、GitHub は **PR 作者自身への review 依頼を拒否する**ため、`-r "tokku5552"` はエラーになる。

代わりに `auto-assign.yml` が機能する。これまで `if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}` で bot 作成 PR をスキップしていたが、作者が実ユーザーになることで発火し、かつ承認不要で走るようになる。reviewer ではなく assignee が付く形に変わる点だけ従来と異なる。

## マージ前に必要な作業

**この順番を守ること。** Secret が無い状態でマージすると、次の水曜 6:00 UTC の `create_release_pr` が失敗する（`actions/checkout` の `token:` が空になりその場でエラーになるので、失敗自体は赤く出て気づける）。

1. fine-grained PAT を発行する
   - 対象リポジトリ: `tokku5552/connpass-advanced-stats` のみ
   - 権限: Contents: Read and write / Pull requests: Read and write
   - Workflows 権限は不要（push するのはリモートに既にあるコミットを指す ref だけなので、workflow ファイルの push 保護に当たらない）
2. Secret を登録する: `gh secret set AUTOMATION_PAT --repo tokku5552/connpass-advanced-stats`
3. この PR をマージする

## 検証について

`create_release_pr.yml` に `workflow_dispatch:` が無いため、現状はマージ後に次の水曜の cron を待つ以外に検証手段がない。手動で確認したい場合は `workflow_dispatch:` を足す（このPRには含めていない）。

## 関連 ISSUE

<!-- close #1-->

## その他

- 調査の詳細な記録（run ID・attempt ごとの conclusion・境界となった PR 番号）は別リポジトリの memo に残してある

🤖 Generated with [Claude Code](https://claude.com/claude-code)