### PR TITLE
fix: bot が作った PR の CI が承認待ちで止まるのを main にも反映

### DIFF
--- a/.github/workflows/create_pr_main_to_develop.yml
+++ b/.github/workflows/create_pr_main_to_develop.yml
@@ -13,6 +13,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
+          # Use a PAT instead of GITHUB_TOKEN. Pull requests opened by
+          # github-actions[bot] have their workflow runs held in action_required
+          # until someone clicks "Approve and run", so CI never runs on its own.
+          token: ${{ secrets.AUTOMATION_PAT }}
 
       - name: Set current datetime as env variable
         env:
@@ -25,15 +29,13 @@ jobs:
       - name: Push Branch
         run: git push origin merge/gha_${{ env.CURRENT_DATETIME }}
 
-      - name: Install Hub
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y hub
-
       - name: Create Pull Request
         env:
-          REVIEWERS: "tokku5552"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTOMATION_PAT }}
           BRANCH_NAME: merge/gha_${{ env.CURRENT_DATETIME }}
         run: |
-          hub pull-request -m "[bot(create_pr_main_to_develop)]: created at ${{ env.CURRENT_DATETIME }}" -b develop -h $BRANCH_NAME  -r "$REVIEWERS"
+          gh pr create \
+            --base develop \
+            --head "$BRANCH_NAME" \
+            --title "[bot(create_pr_main_to_develop)]: created at ${{ env.CURRENT_DATETIME }}" \
+            --body "Sync pull request (main -> develop) after a release."

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -12,6 +12,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: develop
+          # Use a PAT instead of GITHUB_TOKEN. Pull requests opened by
+          # github-actions[bot] have their workflow runs held in action_required
+          # until someone clicks "Approve and run", so CI never runs on its own.
+          token: ${{ secrets.AUTOMATION_PAT }}
 
       - name: Set current datetime as env variable
         env:
@@ -24,15 +28,13 @@ jobs:
       - name: Push Branch
         run: git push origin release/gha_${{ env.CURRENT_DATETIME }}
 
-      - name: Install Hub
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y hub
-
       - name: Create Pull Request
         env:
-          REVIEWERS: "tokku5552"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTOMATION_PAT }}
           BRANCH_NAME: release/gha_${{ env.CURRENT_DATETIME }}
         run: |
-          hub pull-request -m "[bot(create_release_pr)]: created at ${{ env.CURRENT_DATETIME }}" -b main -h $BRANCH_NAME  -r "$REVIEWERS"
+          gh pr create \
+            --base main \
+            --head "$BRANCH_NAME" \
+            --title "[bot(create_release_pr)]: created at ${{ env.CURRENT_DATETIME }}" \
+            --body "Scheduled release pull request (develop -> main)."


### PR DESCRIPTION
PR #854 で `develop` に入れた修正（bot が作成した PR の CI が承認待ち＝`action_required` で止まる問題の対応）が `main` には反映されていませんでした。

`create_pr_main_to_develop.yml` は `main` への push で起動し、**`main` 上のワークフローファイル**が実行されるため、`develop` を直しても実運用の main→develop 同期 PR は旧版（`hub` + `GITHUB_TOKEN` + reviewer 指定）のままで壊れたままでした。本 PR で PR #854 と同一の修正を `main` の 2 ファイルに反映します。

## 変更内容
- PR 作成トークンを `secrets.GITHUB_TOKEN` → `secrets.AUTOMATION_PAT` に変更（github-actions[bot] 作成 PR の CI が承認待ちで止まるのを回避）
- deprecated な `hub pull-request` → `gh pr create` へ移行、`Install Hub` / apt-get ステップを削除
- reviewer 指定 `-r "tokku5552"` を削除

対象ファイル:
- `.github/workflows/create_release_pr.yml`
- `.github/workflows/create_pr_main_to_develop.yml`

## マージ前の前提
リポジトリに Secret `AUTOMATION_PAT` が登録されていること（PR #854 で develop 側は既に本設定に依存済み）。

Slack thread: https://tokku-engineertech.slack.com/archives/C0BS3P5H1GF/p1787891127723109?thread_ts=1787890333.221379&cid=C0BS3P5H1GF

---
_Generated by [Claude Code](https://claude.ai/code/session_012nhSiggv2bFHNoMoyTxQCs)_